### PR TITLE
fix: link libstdc++ explicitly in the C++ extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ ext_modules = [
               ["src/superintervals/intervalmap.pyx"],
               include_dirs=["src"],
               language="c++",
-              extra_compile_args=["-std=c++17"])
+              extra_compile_args=["-std=c++17"],
+              extra_link_args=["-lstdc++"])
 ]
 
 print('PAKCAGES', find_packages(where='src'))  # Add this line for debugging


### PR DESCRIPTION
Some interpreters report CXX=gcc in sysconfig (e.g. Debian's python:3.14-slim), so setuptools links this Cython C++ extension with gcc rather than a C++ driver. gcc omits libstdc++, so the resulting .so has no libstdc++ in NEEDED and import fails with:

`ImportError: undefined symbol: _ZTVN10__cxxabiv117__class_type_infoE`

Linking it explicitly makes the build toolchain-independent.

```
# Setup (Debian slim Python — where the bug lives)

docker run --rm -it python:3.14.6-slim-trixie bash
# inside:
apt-get update && apt-get install -y --no-install-recommends build-essential git
pip install setuptools wheel Cython
git clone https://github.com/znorgaard/superintervals.git && cd superintervals

# Broken (main)
git checkout main
pip install --force-reinstall --no-build-isolation .
python -c "import superintervals"   # -> ImportError: undefined symbol: _ZTVN10__cxxabiv117__class_type_infoE

# Fixed (fix/link-libstdcpp)
git checkout fix/link-libstdcpp
pip install --force-reinstall --no-build-isolation .
python -c "import superintervals; print('import ok')" 
```

Disclaimer: Claude helped with the diagnosis of the issue I hit when migrating to python 3.14 and Claude made the change, I ran through the test case and confirmed the fix works for me.